### PR TITLE
feat: gpt-ossエイリアスをgpt-oss-120bに解決する機能を追加

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -55,6 +55,9 @@ jobs:
             sonnet)
               RESOLVED_MODEL="claude-sonnet-4-20250514"
               ;;
+            gpt-oss)
+              RESOLVED_MODEL="gpt-oss-120b"
+              ;;
             *)
               # エイリアスでない場合はそのまま使用
               RESOLVED_MODEL="$MODEL"


### PR DESCRIPTION
## 概要
GitHub Actionsワークフローで`@claude --model gpt-oss`を指定した場合に、自動的に`gpt-oss-120b`モデルを使用するようにエイリアス機能を追加しました。

## 変更内容
- `.github/workflows/claude-code.yml`のモデルエイリアス解決部分に`gpt-oss`のケースを追加
- `gpt-oss`が指定された場合、`gpt-oss-120b`として処理されるように設定

## 使用例
```
@claude --model gpt-oss
タスクを実行してください
```
上記のコメントで`gpt-oss-120b`モデルが使用されます。

## 背景
`gpt-oss-120b`はREADMEで最高のコストパフォーマンスを持つモデルとして評価されています。短い名前のエイリアスを提供することで、使いやすさを向上させます。

## テスト方法
1. Issueまたはプルリクエストで`@claude --model gpt-oss`を含むコメントを投稿
2. GitHub Actionsログで`Resolved model: gpt-oss-120b`が表示されることを確認
3. 実際に`gpt-oss-120b`モデルが使用されることを確認