### PR TITLE
fix: workflowでクォートを含むコメントがエラーになる問題を修正

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -34,16 +34,22 @@ jobs:
 
     - name: Extract model from comment
       id: extract_model
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        ISSUE_COMMENT_BODY: ${{ github.event.comment.body }}
+        PR_REVIEW_COMMENT_BODY: ${{ github.event.comment.body }}
+        PR_REVIEW_BODY: ${{ github.event.review.body }}
+        ISSUE_BODY: ${{ github.event.issue.body }}
       run: |
         # コメント内容を取得
-        if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
-          COMMENT="${{ github.event.comment.body }}"
-        elif [[ "${{ github.event_name }}" == "pull_request_review_comment" ]]; then
-          COMMENT="${{ github.event.comment.body }}"
-        elif [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
-          COMMENT="${{ github.event.review.body }}"
-        elif [[ "${{ github.event_name }}" == "issues" ]]; then
-          COMMENT="${{ github.event.issue.body }}"
+        if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+          COMMENT="$ISSUE_COMMENT_BODY"
+        elif [[ "$EVENT_NAME" == "pull_request_review_comment" ]]; then
+          COMMENT="$PR_REVIEW_COMMENT_BODY"
+        elif [[ "$EVENT_NAME" == "pull_request_review" ]]; then
+          COMMENT="$PR_REVIEW_BODY"
+        elif [[ "$EVENT_NAME" == "issues" ]]; then
+          COMMENT="$ISSUE_BODY"
         fi
         
         # --model オプションを抽出


### PR DESCRIPTION
## 概要
GitHub Actionsワークフローで、コメント内にダブルクォート（"）が含まれる場合にシェルスクリプトエラーが発生する問題を修正しました。

## 問題
- Issue #23のシナリオ2で、コメント内に`"Claude Code"`のようなクォートを含む文字列があるとワークフローが失敗
- エラー: `No such file or directory`

## 修正内容
- GitHub context変数（`github.event.comment.body`等）を環境変数経由で渡すように変更
- シェルスクリプト内で直接展開せず、環境変数として安全に処理

## テスト
- Issue #23のシナリオ2で動作確認予定

## 関連Issue
- #22: Claude Code Actionsのベンチマークシナリオ設計
- #23: gpt-5モデル ベンチマーク実行